### PR TITLE
'Never-ending' scan

### DIFF
--- a/pymeta/__init__.py
+++ b/pymeta/__init__.py
@@ -47,7 +47,7 @@ class PyMeta():
                 if search =='google' and link_count <= -1:
                     if self.detection_check(resp):
                         print("[!] EXIT")
-                        exit
+                        exit(0)
 
                 for link in soup.findAll('a'):
                     if total_links >= search_cap:

--- a/pymeta/__init__.py
+++ b/pymeta/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# Author: m8r0wn
 
 import re
 import os
@@ -39,6 +38,7 @@ class PyMeta():
             tmp        = len(self.links)
             search_url = self.__urls[search].format(domain, ext, str(link_count + 1))
             try:
+                sleep(self.jitter)
                 headers    = {'User-Agent' : choice(self.__user_agents)}
                 resp       = requests.get(search_url, headers=headers, verify=False, timeout=5)
                 soup       = BeautifulSoup(resp.content, 'html.parser')
@@ -46,8 +46,7 @@ class PyMeta():
                 # Captcha check on first pass of every Google search
                 if search =='google' and link_count <= -1:
                     if self.detection_check(resp):
-                        sleep(self.jitter)
-                        return
+                        exit
 
                 for link in soup.findAll('a'):
                     if total_links >= search_cap:
@@ -77,6 +76,7 @@ class PyMeta():
                 if self.debug: print("[**] Web Search Error: {}".format(str(e)))
 
     def detection_check(self, resp):
+        sleep(self.jitter)
         if "you may be asked to solve the CAPTCHA" in resp.text and self.detection <= 1:
             self.detection += 1
             self.jitter = self.jitter + 5
@@ -94,6 +94,7 @@ class PyMeta():
     def download_files(self, links, write_dir):
         for link in links:
             try:
+                sleep(self.jitter)
                 requests.packages.urllib3.disable_warnings()
                 response = requests.get(link, headers={'User-Agent': choice(self.__user_agents)}, verify=False, timeout=6)
                 with open(write_dir + link.split("/")[-1], 'wb') as f:

--- a/pymeta/__init__.py
+++ b/pymeta/__init__.py
@@ -94,7 +94,7 @@ class PyMeta():
     def download_files(self, links, write_dir):
         for link in links:
             try:
-                sleep(self.jitter)
+                sleep(5)
                 requests.packages.urllib3.disable_warnings()
                 response = requests.get(link, headers={'User-Agent': choice(self.__user_agents)}, verify=False, timeout=6)
                 with open(write_dir + link.split("/")[-1], 'wb') as f:

--- a/pymeta/__init__.py
+++ b/pymeta/__init__.py
@@ -46,6 +46,7 @@ class PyMeta():
                 # Captcha check on first pass of every Google search
                 if search =='google' and link_count <= -1:
                     if self.detection_check(resp):
+                        print("[!] EXIT")
                         exit
 
                 for link in soup.findAll('a'):


### PR DESCRIPTION
When I run into the captcha'ed error, it takes a really huge amount of time to exit the program, and I encounter it even if I put a big jitter (like 60 or 120).  Hence I modify the execution adding several sleep in order to avoid to be captcha'ed and an exit if this happens. It seems to work properly, but maybe you have a better solution. 