### PR TITLE
Fix bug in download_files function

### DIFF
--- a/pymeta/__init__.py
+++ b/pymeta/__init__.py
@@ -50,6 +50,7 @@ class PyMeta():
                 for link in soup.findAll('a'):
                     if total_links >= search_cap:
                         print("[*] {:<4}:{:>3} {}".format(ext, (len(self.links) - tmp), search_url))
+                        sleep(self.jitter)
                         return
                     else:
                         try:
@@ -87,7 +88,7 @@ class PyMeta():
         for link in links:
             try:
                 requests.packages.urllib3.disable_warnings()
-                response = requests.get(link, headers={'User-Agent': choice(random_agent())}, verify=False, timeout=6)
+                response = requests.get(link, headers={'User-Agent': random_agent()}, verify=False, timeout=6)
                 with open(write_dir + link.split("/")[-1], 'wb') as f:
                     f.write(response.content)
             except KeyboardInterrupt:


### PR DESCRIPTION
I notice that often the program doesn't download all the file it claims to have found, so I investigated a bit and I found that Pymeta was setting as user-agent a random character due to the fact that there were the choice function applied to what random_agent() returns, that is a string and not a list.
I also think that there is a missing sleep in case of more results than the max_results are found. Maybe it can help to avoid being captcha'ed.